### PR TITLE
Make AMD module 'angular-logX' the main AMD module

### DIFF
--- a/demos/build/bower.json
+++ b/demos/build/bower.json
@@ -3,20 +3,20 @@
   "version": "0.1.1",
   "devDependencies": {
     "headjs-notify": "0.9.7",
-    "requirejs": "~2.1.8",
+    "requirejs": "~2.1.15",
     "requirejs-text": "2.0.10",
-    "angular": "~1.2",
+    "angular": "~1.3",
     "angular-route": "~1",
     "angular-bootstrap": "~0.5.0",
-    "angular-logDecorator": "^0.1.2"
+    "angular-logX": "^0.1.5"
   },
   "dependencies": {
       "headjs-notify": "0.9.7",
-      "requirejs": "~2.1.8",
+      "requirejs": "~2.1.15",
       "requirejs-text": "2.0.10",
-      "angular": "~1.2",
+      "angular": "~1.3",
       "angular-route": "~1",
       "angular-bootstrap": "~0.5.0",
-      "angular-logDecorator": "^0.1.2"
+      "angular-logX": "^0.1.5"
   }
 }

--- a/src/angular-logX.js
+++ b/src/angular-logX.js
@@ -4,11 +4,11 @@
     /**
      * Build a `mindspace.logX` module that registers and configures the LogDecorator for $log
      *
-     * If custom applications, simply add `mindspace.logX` namespace to the application's module
-     * dependency list
+     * If custom applications need decorated log entries, simply require `angular-logX`
+     * and add `mod.name` to the application's module dependency list (where `mod = require('angular-logX')`).
      */
 
-    require([
+    define([
 
           "mindspace/logger/LogDecorator"
 
@@ -16,7 +16,7 @@
     {
         var moduleName = 'mindspace.logX';
 
-        angular.module( moduleName , [ ] )
+        return angular.module( moduleName , [ ] )
                .config( LogDecorator            );
 
     });

--- a/src/angular-logX.js
+++ b/src/angular-logX.js
@@ -3,7 +3,6 @@
 
     /**
      * Build a `mindspace.logX` module that registers and configures the LogDecorator for $log
-     * Also load the ExternalLogger for subsequent require(["mindspace/logger/ExternalLogger"])
      *
      * If custom applications, simply add `mindspace.logX` namespace to the application's module
      * dependency list
@@ -19,9 +18,8 @@
     require([
 
           "mindspace/logger/LogDecorator"
-        , "mindspace/logger/ExternalLogger"
 
-    ], function( LogDecorator, ExternalLogger )
+    ], function( LogDecorator )
     {
         var moduleName = 'mindspace.logX';
 

--- a/src/angular-logX.js
+++ b/src/angular-logX.js
@@ -6,13 +6,6 @@
      *
      * If custom applications, simply add `mindspace.logX` namespace to the application's module
      * dependency list
-     *
-     * This module also exposes (via require( <xxx> ) calls the following:
-     *
-     *   - supplant()
-     *   - makeTryCatch()
-     *   - ExternalLogger.getInstance()
-     *
      */
 
     require([


### PR DESCRIPTION
After merging this PR, we'd have the situation:
1. If you need a decorated logger, just require 'mindspace/logger/ExternalLogger'
2. If you need decorated loggers with AngularJS, require 'angular-logX' and add require('angular-logX').name to your AngularJS module.

This solution is not tainted with side-effects as the current solution is.
